### PR TITLE
Add variables with full interpolation text area

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ This section is optional, but if you wish to provide constant variables for your
 
 Certain variables are provided to every query. These include:
 
-| Variable        | Type   | Description                                                                    | Grafana counterpart                                                                                               |
-|-----------------|--------|--------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
-| `from`          | Number | Epoch milliseconds of the "from" time                                          | [$__from](https://grafana.com/docs/grafana/latest/dashboards/variables/add-template-variables/#__from-and-__to)   |
-| `to`            | Number | Epoch milliseconds of the "to" time                                            | [$__to](https://grafana.com/docs/grafana/latest/dashboards/variables/add-template-variables/#__from-and-__to)     |
-| `interval_ms`   | Number | The suggested duration between time points in a time series query              | [$__interval_ms](https://grafana.com/docs/grafana/latest/dashboards/variables/add-template-variables/#__interval) |
-| `maxDataPoints` | Number | Maximum number of data points that should be returned from a time series query | N/A                                                                                                               |
-| `refId`         | String | Unique identifier of the query, set by the frontend call                       | N/A                                                                                                               |
+| Variable        | Type   | Description                                                                    | Grafana counterpart                                                                                               | Execute Button Support |
+|-----------------|--------|--------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|------------------------|
+| `from`          | Number | Epoch milliseconds of the "from" time                                          | [$__from](https://grafana.com/docs/grafana/latest/dashboards/variables/add-template-variables/#__from-and-__to)   | Yes                    |
+| `to`            | Number | Epoch milliseconds of the "to" time                                            | [$__to](https://grafana.com/docs/grafana/latest/dashboards/variables/add-template-variables/#__from-and-__to)     | Yes                    |
+| `interval_ms`   | Number | The suggested duration between time points in a time series query              | [$__interval_ms](https://grafana.com/docs/grafana/latest/dashboards/variables/add-template-variables/#__interval) | No                     |
+| `maxDataPoints` | Number | Maximum number of data points that should be returned from a time series query | N/A                                                                                                               | No                     |
+| `refId`         | String | Unique identifier of the query, set by the frontend call                       | N/A                                                                                                               | No                     |
 
 An example usage is shown in the most basic query:
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,22 @@ One of the pros of this is simplicity, with the advantage of not having to worry
 
 REMEMBER: Variable interpolation does not work for alerting queries, or any query that is executed without the frontend component.
 
+#### Advanced Variable Interpolation
+
+If you need to incorporate numeric variables in the variables passed to your query, you cannot use the default variables editor, you must instead use Advanced Variables JSON.
+Click the checkbox to define it. Once you do, you can write JSON that is not valid until AFTER it is interpolated. For instance:
+
+```json
+{
+  "age": $age
+}
+```
+
+The above example is valid assuming that `$age` evaluates to a number that causes the resulting JSON to be valid.
+You can use both advanced variables JSON and the regular variables as described above. Just realize that advanced variables JSON will take precedence for any variables defined twice.
+
+WARNING: Only use advanced variables JSON if it is required to. If any part of the resulting JSON is invalid, no part of the advanced variable interpolation will be passed to the query.
+
 ### Documentation Explorer
 
 [GraphiQL](https://github.com/graphql/graphiql) provides a documentation explorer and can be opened on the left side of the GraphiQL editor

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -1,5 +1,5 @@
 import React, {ChangeEvent, KeyboardEvent, useEffect, useMemo, useRef} from 'react';
-import {Button, IconButton, InlineField, Input, Select} from '@grafana/ui';
+import {Button, Checkbox, IconButton, InlineField, Input, Select, TextArea} from '@grafana/ui';
 import {CoreApp, QueryEditorProps} from '@grafana/data';
 import {DataSource} from '../datasource';
 import {
@@ -136,7 +136,8 @@ export function QueryEditor(props: Props) {
   );
 }
 
-function InnerQueryEditor({ query, onChange, onRunQuery, datasource }: Props) {
+function InnerQueryEditor({ query, onChange, onRunQuery, datasource, app }: Props) {
+  const isBackendOnlyQuery = app === CoreApp.CloudAlerting || app === CoreApp.UnifiedAlerting;
   const editorContext = useEditorContext();
   const labelToAddRef = useRef<HTMLInputElement>(null);
 
@@ -381,6 +382,32 @@ function InnerQueryEditor({ query, onChange, onRunQuery, datasource }: Props) {
             />
           </InlineField>
         </div>
+        {!isBackendOnlyQuery && <>
+          <Checkbox
+            label="Define Advanced Variables JSON"
+            value={query.variablesWithFullInterpolation !== undefined}
+            onChange={(event) => {
+              onChange({
+                ...query,
+                variablesWithFullInterpolation: event.currentTarget.checked ? "{\n  \n}" : undefined
+              })
+            }}
+          />
+          {query.variablesWithFullInterpolation !== undefined &&
+            <TextArea
+              style={{
+                minHeight:"10em"
+              }}
+              value={query.variablesWithFullInterpolation}
+              onChange={(event) => {
+                onChange({
+                  ...query,
+                  variablesWithFullInterpolation: event.currentTarget.value
+                })
+              }}
+            />
+          }
+        </>}
       </div>
       <h3 className="page-heading">Parsing Options</h3>
       <div className="gf-form-group">

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,12 +1,5 @@
-import {
-  AnnotationSupport,
-  CoreApp,
-  DataQueryRequest,
-  DataQueryResponse,
-  DataSourceInstanceSettings,
-} from '@grafana/data';
+import {AdHocVariableFilter, AnnotationSupport, CoreApp, DataSourceInstanceSettings, ScopedVars,} from '@grafana/data';
 import {DataSourceWithBackend, getTemplateSrv} from '@grafana/runtime';
-import {Observable} from 'rxjs';
 
 import {
   DEFAULT_ALERTING_QUERY,
@@ -44,35 +37,37 @@ export class DataSource extends DataSourceWithBackend<WildGraphQLAnyQuery, WildG
     }
     return DEFAULT_QUERY;
   }
-  query(request: DataQueryRequest<WildGraphQLAnyQuery>): Observable<DataQueryResponse> {
-
-    // Everything you see going on here is to do variable substitution for the values of the provided variables.
+  applyTemplateVariables(query: WildGraphQLAnyQuery, scopedVars: ScopedVars, filters?: AdHocVariableFilter[]): WildGraphQLAnyQuery {
     const templateSrv = getTemplateSrv();
-    const newTargets: WildGraphQLAnyQuery[] = request.targets.map((target) => {
-      const variables = getQueryVariablesAsJson(target);
-      const interpolatedVariables = interpolateVariables(variables, templateSrv, request.scopedVars);
-      const interpolatedVariablesWithFullInterpolationObject = target.variablesWithFullInterpolation === undefined
-        ? {}
-        : JSON.parse( // TODO JSON.parse may throw a SyntaxError. For now, we're OK with that, but we may consider how to make this so it doesn't prevent ALL queries from being executed
-          templateSrv.replace(target.variablesWithFullInterpolation, request.scopedVars)
-        );
-      const newVariables = {
-        ...interpolatedVariables,
-        ...interpolatedVariablesWithFullInterpolationObject
+    const variables = getQueryVariablesAsJson(query);
+    const interpolatedVariables = interpolateVariables(variables, templateSrv, scopedVars);
+    let interpolatedVariablesWithFullInterpolation: Record<string, any> = {};
+    if (query.variablesWithFullInterpolation !== undefined) {
+      // variablesWithFullInterpolation are inherently unsafe and should only be used when necessary.
+      //   We have to check to make sure parsing it does not result in an error.
+      //   We can only parse it after calling templateSrv.replace()
+      const interpolatedString = templateSrv.replace(query.variablesWithFullInterpolation, scopedVars);
+      try {
+        interpolatedVariablesWithFullInterpolation = JSON.parse(interpolatedString);
+      } catch (e) {
+        if (e instanceof SyntaxError) {
+          console.error("Error parsing variablesWithFullInterpolation for refId: " + query.refId + ". argument to JSON.parse(), error:", interpolatedString, e);
+          // We don't have a good way of indicating to the caller than an error has occurred,
+          //   so we instead continue without merging the variablesWithFullInterpolation
+        } else {
+          throw e;
+        }
       }
-      return {
-        ...target,
-        variablesWithFullInterpolation: undefined, // the backend does not care about this value, so don't pass it
-        variables: newVariables,
-      }
-    })
-    const newRequest = {
-      ...request,
-      targets: newTargets
+    }
+    const newVariables = {
+      ...interpolatedVariables,
+      ...interpolatedVariablesWithFullInterpolation
     };
-
-    // we aren't really supposed to change this method, but we do it anyway :)
-    return super.query(newRequest);
+    return {
+      ...query,
+      variablesWithFullInterpolation: undefined, // the backend does not care about this value, so don't pass it
+      variables: newVariables,
+    };
   }
   // metricFindQuery(query: any, options?: any): Promise<MetricFindValue[]> {
   //   // https://grafana.com/developers/plugin-tools/create-a-plugin/extend-a-plugin/add-support-for-variables

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,19 +81,26 @@ export function getQueryVariablesAsJson(query: WildGraphQLCommonQuery): Record<s
   return variables;
 }
 
+export interface WildGraphQLFrontendQuery extends WildGraphQLCommonQuery {
+  variablesWithFullInterpolation?: string;
+}
+
 /**
  * This interface represents the main type of query, which is used for most queries in Grafana
  */
-export interface WildGraphQLMainQuery extends WildGraphQLCommonQuery {
+export interface WildGraphQLMainQuery extends WildGraphQLFrontendQuery {
 }
 
-export interface WildGraphQLAnnotationQuery extends WildGraphQLCommonQuery {
+export interface WildGraphQLAnnotationQuery extends WildGraphQLFrontendQuery {
+}
+export interface WildGraphQLAlertingQuery extends WildGraphQLCommonQuery {
 }
 
 /** This type represents the possible options that can be stored in the datasource JSON for queries */
-export type WildGraphQLAnyQuery = (WildGraphQLMainQuery | WildGraphQLAnnotationQuery) &
+export type WildGraphQLAnyQuery = (WildGraphQLMainQuery | WildGraphQLAnnotationQuery | WildGraphQLAlertingQuery) &
   Partial<WildGraphQLMainQuery> &
-  Partial<WildGraphQLAnnotationQuery>;
+  Partial<WildGraphQLAnnotationQuery> &
+  Partial<WildGraphQLAlertingQuery>;
 
 
 /**
@@ -129,7 +136,7 @@ export const DEFAULT_QUERY: Partial<WildGraphQLMainQuery> = {
   ]
 };
 
-export const DEFAULT_ALERTING_QUERY: Partial<WildGraphQLMainQuery> = {
+export const DEFAULT_ALERTING_QUERY: Partial<WildGraphQLAlertingQuery> = {
   queryText: `query ($from: String!, $to: String!) {
   queryStatus(sourceId: "default", from: $from, to: $to) {
     batteryVoltage {

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -17,7 +17,7 @@ import {ScopedVars} from "@grafana/data";
 const AUTO_POPULATED_VARIABLES: Record<string, (templateSrv: TemplateSrv) => any> = {
   "from": templateSrv => Number(templateSrv.replace("$__from")),
   "to": templateSrv => Number(templateSrv.replace("$__to")),
-  "interval_ms": templateSrv => Number(templateSrv.replace("$__interval_ms")),
+  // While interval_ms can be obtained via $__interval_ms, but only as a ScopedVar, which we don't have easy access to inside a fetcher
 };
 
 /**


### PR DESCRIPTION
This change adds the option of specifying an additional variables object, which will be stored as a JSON string and always is fully interpolated as a string itself, rather than the strings inside the JSON, like is done in the GraphiQL editor.

This change is fully backwards compatible, and does not remove the behavior of the existing variables field, but instead provides a more advanced and also more unsafe option to create the variables JSON.